### PR TITLE
fix: update sys-form-buttom styles

### DIFF
--- a/src/components/sys-form-button.stories.js
+++ b/src/components/sys-form-button.stories.js
@@ -10,7 +10,7 @@ import SysFormButton from './sys-form-button.vue'
 
 storiesOf('Components|Button', module)
   .addDecorator(withKnobs)
-  .add('default', () => ({
+  .add('normal', () => ({
     components: { SysFormButton },
     props: {
       active: { default: boolean('active', false) },
@@ -32,6 +32,37 @@ storiesOf('Components|Button', module)
         :size="size"
         :tag="tag"
       >
+        {{ text }}
+      </sys-form-button>
+    `
+  }))
+  .add('with an icon', () => ({
+    components: { SysFormButton },
+    props: {
+      active: { default: boolean('active', false) },
+      block: { default: boolean('block', false) },
+      color: { default: select('color', ['normal', 'primary', 'secondary'], 'normal') },
+      disabled: { default: boolean('disabled', false) },
+      href: { default: text('href', '') },
+      size: { default: select('size', ['small', 'medium', 'large', 'huge'], 'medium') },
+      tag: { default: text('tag', '') },
+      text: { default: text('text', 'Button') }
+    },
+    template: `
+      <sys-form-button
+        :active="active"
+        :block="block"
+        :color="color"
+        :disabled="disabled"
+        :href="href"
+        :size="size"
+        :tag="tag"
+      >
+        <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="user" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="svg-inline--fa fa-user fa-w-14">
+          <path fill="currentColor" d="M224 256c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z" >
+          </path>
+        </svg>
+
         {{ text }}
       </sys-form-button>
     `

--- a/src/components/sys-form-button.vue
+++ b/src/components/sys-form-button.vue
@@ -173,7 +173,6 @@ export default {
     line-height: 1;
     text-align: center;
     text-decoration: none;
-    text-transform: uppercase;
     transition-duration: 100ms;
     transition-property: background-color, border-color, box-shadow;
     transition-timing-function: ease;
@@ -212,6 +211,7 @@ export default {
     background-color: var(--color-light-form-button-primary);
     border-color: var(--color-light-form-button-primary);
     color: var(--color-light-form-button-primary-contrast);
+    text-transform: uppercase;
   }
 
   .button--primary:hover,
@@ -235,6 +235,7 @@ export default {
   .button--secondary {
     background-color: var(--color-light-form-button-secondary);
     border-color: var(--color-light-form-button-secondary);
+    text-transform: uppercase;
   }
 
   .button--secondary:hover,
@@ -306,7 +307,7 @@ export default {
 
   .button--block {
     display: block;
-    margin: 0.5rem 0;
+    margin: 1rem 0;
     width: 100%;
   }
 
@@ -320,7 +321,7 @@ export default {
 
   /** TODO: Better icon handling in this component **/
   .button > svg {
-    height: 1rem;
-    margin-right: 0.5ch;
+    height: 1em;
+    margin: 0 0.5ch;
   }
 </style>


### PR DESCRIPTION
- Adds a demo page with an icon in the button
- Only text transform on the colored buttons
- Adds more margin to the top and bottom of block button

All needed for the account page mockups
![Screenshot from 2020-02-03 12 46 03](https://user-images.githubusercontent.com/3385679/73685326-34e05a80-4683-11ea-881e-c941e23980c1.png)
