### PR TITLE
Add missing CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @system76/web-engineering


### PR DESCRIPTION
This is the same CODEOWNERS file we've used in our other projects. This ensures that all PRs / Issues that are opened are assigned the `web-engineering` team as reviewers automagically.