### PR TITLE
fix: color of secondary button not set

### DIFF
--- a/src/components/sys-form-button.vue
+++ b/src/components/sys-form-button.vue
@@ -235,6 +235,7 @@ export default {
   .button--secondary {
     background-color: var(--color-light-form-button-secondary);
     border-color: var(--color-light-form-button-secondary);
+    color: var(--color-light-form-button-secondary-contrast);
     text-transform: uppercase;
   }
 


### PR DESCRIPTION
This color was not set, so in artoo (where the `a` tag has a color set) it shows up orange instead of the white it should be.