### PR TITLE
feat: remove horizontal margin from buttons

### DIFF
--- a/src/components/sys-form-button.vue
+++ b/src/components/sys-form-button.vue
@@ -352,7 +352,8 @@
   }
 
   .button:not(.button--block) {
-    margin: 0.25rem 0.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 
   .button--horizontal {

--- a/src/components/sys-form.vue
+++ b/src/components/sys-form.vue
@@ -165,6 +165,6 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
-    margin: -0.4rem -0.5rem 0;
+    margin: -0.4rem 0 0;
   }
 </style>


### PR DESCRIPTION
Instead of doing horizontal margins for buttons, this does the standard browser space between `inline-block` elements. This is a single space width between buttons. We won't have control over that space, but buttons will line up with text without needing to do negative margin stuff.