### PR TITLE
feat: add ghost prop for sys-form-button

### DIFF
--- a/src/components/sys-form-button.stories.mdx
+++ b/src/components/sys-form-button.stories.mdx
@@ -35,6 +35,27 @@ but changes the appearance.
   </Story>
 </Preview>
 
+### Ghost
+
+Sometimes we want the button to look like normal text until a user interacts
+with it. If you set `:ghost="true"` on the button, it will show like normal text
+until a user hovers, focuses, or interacts with it.
+
+<Preview>
+  <Story name="Ghost">
+    {{
+      components: { SysFormButton },
+      template: `
+        <div>
+          <sys-form-button color="normal" :ghost="true">normal</sys-form-button>
+          <sys-form-button color="primary" :ghost="true">primary</sys-form-button>
+          <sys-form-button color="secondary" :ghost="true">secondary</sys-form-button>
+        </div>
+      `
+    }}
+  </Story>
+</Preview>
+
 ### Sizes
 
 There are four different sizes. Each one has it's own break points, so please

--- a/src/components/sys-form-button.vue
+++ b/src/components/sys-form-button.vue
@@ -71,6 +71,12 @@
         default: false
       },
 
+      /** If the button should be invisible until interacted with */
+      ghost: {
+        type: Boolean,
+        default: false
+      },
+
       /**
        * The location the button so link to. Same as HTML a link href attribute.
        */
@@ -124,6 +130,7 @@
           'button--active': this.active,
           'button--block': this.block,
           'button--disabled': this.disabled,
+          'button--ghost': this.ghost,
           'button--outline': this.outline,
           [`button--${this.color}`]: true,
           [`button--${this.size}`]: true,
@@ -294,6 +301,20 @@
   .button--secondary:disabled {
     background-color: var(--color-light-form-button-secondary);
     border-color: var(--color-light-form-button-secondary);
+  }
+
+  .button--ghost:not(
+    :hover,
+    :focus,
+    :focus-within,
+    .button--active,
+    :active,
+    .button--disabled,
+    :disabled
+  ) {
+    background-color: transparent;
+    border-color: transparent;
+    color: inherit;
   }
 
   /**


### PR DESCRIPTION
Adds a ghost prop to sys-form-button. This makes the button look like regular text until interacted with.